### PR TITLE
Added missing header; fix compilation with 1.2.0.

### DIFF
--- a/tools/mruby-memprof/mruby.c
+++ b/tools/mruby-memprof/mruby.c
@@ -6,6 +6,7 @@
 #include "mruby/compile.h"
 #include "mruby/dump.h"
 #include "mruby/variable.h"
+#include "mruby/string.h"
 
 #ifndef ENABLE_STDIO
 static void


### PR DESCRIPTION
Small fix to make memprof compilable with MRuby 1.2.0.
